### PR TITLE
Suggestion of 0.7.0 version (git tag)

### DIFF
--- a/bin/build-phar.php
+++ b/bin/build-phar.php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-if (!@include __DIR__.'/../vendor/.composer/autoload.php') {
+if (!@include __DIR__.'/../vendor/autoload.php') {
     die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL);

--- a/bin/yuml-php
+++ b/bin/yuml-php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-if ((!@include __DIR__.'/../../../.composer/autoload.php') && (!@include __DIR__.'/../vendor/.composer/autoload.php')) {
+if ((!@include __DIR__.'/../../../autoload.php') && (!@include __DIR__.'/../vendor/autoload.php')) {
     die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL);

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,6 @@
 {
     "name" : "digitalkaoz/yuml-php",
-    "target-dir" : "vendor/",
     "homepage" : "https://github.com/digitalkaoz/yuml-php",
-    "version" : "0.6.0",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
 
     "require": {
         "php": ">=5.3.2",
-        "symfony/finder":   ">=2.0.9,<=2.1",
-        "symfony/console":  ">=2.0.9,<=2.1",
+        "symfony/finder":   ">=2.0.9",
+        "symfony/console":  ">=2.0.9",
         "kriswallsmith/buzz": ">=0.5"
     },
 


### PR DESCRIPTION
This should fix the new composer path to autoload.php and remove max version of dependencies.

Changes:
- Fix composer autoload path;
- Remove optional fields. Use git tags for version is better then fix in composer.json;
- Change composer.json to do not fix max version of dependencies.
